### PR TITLE
Add option to regrid multiple increment files

### DIFF
--- a/README
+++ b/README
@@ -4,5 +4,6 @@ To compile regridding tool in stand-alone mode:
  load GDASApp modules
 > cd DA-utils
 > mkdir build
+> cd build
 > ecbuild ../bundle
 > make

--- a/src/regridStates/grids_IO.F90
+++ b/src/regridStates/grids_IO.F90
@@ -1,6 +1,6 @@
  module grids_IO
  ! ESMF grid-specific routines for GFS regridding program, including IO.
- ! 
+ !
  ! Clara Draper, Aug 2024.
 
  use esmf
@@ -16,7 +16,7 @@
  integer, public, parameter  :: vtype_water=0, & ! TO DO - which veg classification is this?
                                 vtype_landice=15 ! used for soil mask
  ! mask values for soilsnow_mask calculated in the GSI EnKF
- integer, public, parameter  :: mtype_water=0, & 
+ integer, public, parameter  :: mtype_water=0, &
                                 mtype_snow=2
  type, public  :: grid_setup_type
         character(7)   :: descriptor
@@ -30,7 +30,7 @@
         integer        :: ires
         integer        :: jres
  end type
- 
+
  public :: setup_grid, &
            read_into_fields, &
            write_from_fields
@@ -48,7 +48,7 @@
  type(grid_setup_type), intent(in)    :: grid_setup
  integer, intent(in)            :: localpet, npets
 
- ! INTENT OUT 
+ ! INTENT OUT
  type(esmf_grid)                :: mod_grid
 
  ! LOCAL
@@ -66,7 +66,7 @@
      call create_grid_fv3(grid_setup%ires, trim(grid_setup%dir_coord), npets, localpet ,mod_grid)
  case ('gau_inc')
      call create_grid_gauss(grid_setup, npets, localpet,  mod_grid)
- case default 
+ case default
      call error_handler("unknown grid_setup%descriptor in setup_grid", 1)
  end select
 
@@ -100,7 +100,7 @@
  if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
     call error_handler("in GridAddItem mask", ierr)
 
- call ESMF_GridGetItem(mod_grid, & 
+ call ESMF_GridGetItem(mod_grid, &
                        itemflag=ESMF_GRIDITEM_MASK, &
                        farrayPtr=ptr_mask, &
                        rc=ierr)
@@ -129,9 +129,9 @@
 
  ! read variables from fv3 netcdf restart file into ESMF Fields
  subroutine read_into_fields(localpet, i_dim, j_dim , fname_read, dir_read, &
-                               grid_setup, n_vars, variable_list, fields) 
- 
- implicit none 
+                               grid_setup, n_vars, variable_list, fields)
+
+ implicit none
 
  ! INTENT IN
  integer, intent(in)             :: localpet, i_dim, j_dim, n_vars
@@ -140,8 +140,8 @@
  type(grid_setup_type), intent(in)        :: grid_setup
 
  character(len=15), dimension(n_vars), intent(in)   :: variable_list
- 
- ! INTENT OUT 
+
+ ! INTENT OUT
  type(esmf_field), dimension(1,n_vars), intent(inout) :: fields
 
  ! LOCAL
@@ -155,7 +155,7 @@
  if (localpet==0) then
      allocate(array_in(n_vars,i_dim, j_dim))
      allocate(array2D(i_dim, j_dim))
- else 
+ else
      allocate(array_in(0,0,0))
      allocate(array2D(0,0))
  end if
@@ -163,12 +163,12 @@
  select case (grid_setup%descriptor)
  case ('fv3_rst')
      n_files=n_tiles
- case ('gau_inc') 
+ case ('gau_inc')
      n_files=1
  case default
      call error_handler("unknown grid_setup%descriptor in read into fields", 1)
  end select
-     
+
  do tt = 1, n_files
 
       ! read from restart
@@ -208,7 +208,7 @@
       enddo
 
  enddo
- 
+
  ! clean up
  deallocate(array_in)
 
@@ -218,8 +218,8 @@
 
  subroutine lonlat_read_into_fields(localpet, i_dim, j_dim, fname_read, dir_read, &
                                grid_setup, gauss_grid, lon_fields, lat_fields)
- 
- implicit none 
+
+ implicit none
 
  ! INTENT IN
  integer, intent(in)             :: localpet, i_dim, j_dim
@@ -228,8 +228,8 @@
  type(grid_setup_type), intent(in)        :: grid_setup
  type(esmf_grid), intent(in)     :: gauss_grid
 
- 
- ! INTENT OUT 
+
+ ! INTENT OUT
  type(esmf_field), dimension(2), intent(out) :: lon_fields
  type(esmf_field), dimension(2), intent(out) :: lat_fields
 
@@ -247,21 +247,21 @@
  ! center coord names
  lonvar_list(1) = 'grid_center_lon'
  latvar_list(1) = 'grid_center_lat'
- 
+
  ! corner coord names
  lonvar_list(2) = 'grid_corner_lon'
  latvar_list(2) = 'grid_corner_lat'
 
- ! Create the fields 
+ ! Create the fields
  do v=1,2
-        vname="gauss_grid_" // trim(lonvar_list(v)) 
+        vname="gauss_grid_" // trim(lonvar_list(v))
         lon_fields(v) = ESMF_FieldCreate(gauss_grid, &
                                    typekind=ESMF_TYPEKIND_R8, &
                                    staggerloc=ESMF_STAGGERLOC_CENTER, &
                                    name=vname, rc=ierr)
         if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
         call error_handler("IN FieldCreate", ierr)
- 
+
         vname="gauss_grid_" // trim(latvar_list(v))
         lat_fields(v) = ESMF_FieldCreate(gauss_grid, &
                                    typekind=ESMF_TYPEKIND_R8, &
@@ -270,12 +270,12 @@
         if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
         call error_handler("IN FieldCreate", ierr)
  enddo
- 
+
  if (localpet==0) then
      allocate(array_lat(2, i_dim, j_dim))
      allocate(array_lon(2, i_dim, j_dim))
      allocate(array2d( i_dim, j_dim))
- else 
+ else
      allocate(array_lat(2,0,0))
      allocate(array_lon(2,0,0))
      allocate(array2d(0,0))
@@ -316,7 +316,7 @@
                 array_tmp = reshape(vec1,(/i_dim,j_dim/))
                 array_lat(1,:,j) = array_tmp(:,j_dim+1-j)
         enddo
-     else 
+     else
         array_lat(1,:,:) = reshape(vec1,(/i_dim,j_dim/))
      endif
 
@@ -328,7 +328,7 @@
 
      ierr=nf90_get_var(ncid, id_var, vec4)
      call netcdf_err(ierr, 'reading variable' )
- 
+
      ! 2nd element of vec4 is the NW corner
      array_lon(2,:,:) = reshape(vec4(2,:),(/i_dim,j_dim/))
 
@@ -346,7 +346,7 @@
                 array_tmp = reshape(vec4(2,:),(/i_dim,j_dim/))
                 array_lat(2,:,j) = array_tmp(:,j_dim+1-j)
         enddo
-     else 
+     else
         ! 2nd element of vec4 is the NW corner
         array_lat(2,:,:) = reshape(vec4(2,:),(/i_dim,j_dim/))
      endif
@@ -354,7 +354,7 @@
      ierr = nf90_close(ncid)
   endif
 
-  ! scatter the arrays into the fields 
+  ! scatter the arrays into the fields
   do v =1,2
 
       ! scatter longitudes
@@ -363,7 +363,7 @@
       call ESMF_FieldScatter(lon_fields(v), array2d, rootpet=0,  rc=ierr)
       if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
          call error_handler("IN FieldScatter", ierr)
-     
+
       ! scatter latitude
       if (localpet==0) print *, 'scattering lat', latvar_list(v)
       array2d=array_lat(v,:,:)
@@ -378,12 +378,12 @@
  deallocate(array2d)
 
  end subroutine lonlat_read_into_fields
-! write variables from ESMF Fields into netcdf restart-like file 
+! write variables from ESMF Fields into netcdf restart-like file
 
  subroutine write_from_fields(localpet, i_dim, j_dim , fname_out, dir_out, &
-                                n_vars, n_tims, variable_list, fields) 
+                                n_vars, n_tims, variable_list, fields)
 
- implicit none 
+ implicit none
 
  ! INTENT IN
  integer, intent(in)             :: localpet, i_dim, j_dim,  n_vars, n_tims
@@ -407,7 +407,7 @@
  if (localpet==0) then
      allocate(array_out(n_vars, i_dim, j_dim, n_tims))
      allocate(array2D(i_dim, j_dim))
- else 
+ else
      allocate(array_out(0,0,0,0))
      allocate(array2D(0,0))
  end if
@@ -416,15 +416,15 @@
 
       ! fetch data (all PETs)
       do t =1 , n_tims
-      do v = 1, n_vars
-          call ESMF_FieldGather(fields(t,v), array2D, rootPet=0, tile=tt, rc=ierr)
-          if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
-             call error_handler("IN FieldGather", ierr)
-          array_out(v,:,:,t) = array2D
-      enddo
+          do v = 1, n_vars
+              call ESMF_FieldGather(fields(t,v), array2D, rootPet=0, tile=tt, rc=ierr)
+              if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
+                 call error_handler("IN FieldGather", ierr)
+              array_out(v,:,:,t) = array2D
+          enddo
       enddo
 
-      ! write to netcdf 
+      ! write to netcdf
       if (localpet == 0) then
 
          ! open file, set dimensions
@@ -435,7 +435,7 @@
          call netcdf_err(ierr, 'creating file='//trim(fname) )
 
          if (n_tims>1) then ! UFS_UTILS expects input with no time dim
-                           ! GFS (for IAU) expects a time dimension 
+                           ! GFS (for IAU) expects a time dimension
                            ! later: update GFS to not expect a time dimension
              ierr = nf90_def_dim(ncid, 'Time', n_tims, id_t)
              call netcdf_err(ierr, 'defining taxis dimension' )
@@ -452,21 +452,21 @@
 
              if (n_tims>1) then
                  ! UFS model code to read in the increments is expecting
-                 ! dimensions: time, y, x (in the ncdump read out - which reverses fortran indexes) 
+                 ! dimensions: time, y, x (in the ncdump read out - which reverses fortran indexes)
                  ! need dimensions to be x,y,t below.
                  ierr = nf90_def_var(ncid, trim(variable_list(v)), NF90_DOUBLE, &
                                      (/id_x, id_y, id_t/) , id_var)
 
                  call netcdf_err(ierr, 'defining '//variable_list(v) )
-             else 
+             else
                  ierr = nf90_def_var(ncid, trim(variable_list(v)), NF90_DOUBLE, &
                                      (/id_x, id_y/) , id_var)
              endif
 
              call netcdf_err(ierr, 'defining '//variable_list(v) )
-             
-             ierr = nf90_put_var( ncid, id_var, array_out(v,:,:,:) ) 
-             call netcdf_err(ierr, 'writing '//variable_list(v) ) 
+
+             ierr = nf90_put_var( ncid, id_var, array_out(v,:,:,:) )
+             call netcdf_err(ierr, 'writing '//variable_list(v) )
 
          enddo
 
@@ -475,14 +475,14 @@
       endif
 
  enddo
- 
+
  ! clean up
  deallocate(array_out)
 
  end subroutine write_from_fields
 
  ! subroutine to create grid object for fv3 grid
- ! also sets distribution across procs 
+ ! also sets distribution across procs
 
  subroutine create_grid_fv3(res_atm, dir_fix, npets, localpet, fv3_grid)
 
@@ -491,16 +491,16 @@
  integer, intent(in)    :: res_atm
  character(*), intent(in)       :: dir_fix
 
- ! INTENT OUT 
+ ! INTENT OUT
  type(esmf_grid)                :: fv3_grid
 
- integer                :: ierr, extra, tile 
+ integer                :: ierr, extra, tile
  integer                :: decomptile(2,n_tiles)
- 
+
  character(len=5)       :: rchar
  character(len=200)     :: fname, dir_fix_res
 
- if (localpet == 0) print*," creating fv3 grid for ", res_atm 
+ if (localpet == 0) print*," creating fv3 grid for ", res_atm
 
 ! pet distribution
  extra = npets / n_tiles
@@ -508,11 +508,11 @@
    decomptile(:,tile)=(/1,extra/)
  enddo
 
- ! mosaic file 
+ ! mosaic file
  write(rchar,'(i3)') res_atm
  dir_fix_res = dir_fix//"/C"//trim(adjustl(rchar))//"/"
  fname = trim(dir_fix_res)//"/C"//trim(adjustl(rchar))// "_mosaic.nc"
- 
+
 ! create the grid
  fv3_grid = ESMF_GridCreateMosaic(filename=trim(fname), &
                                   regDecompPTile=decomptile, &
@@ -531,8 +531,8 @@
  ! INTENT IN
  type(grid_setup_type), intent(in) :: grid_setup
  integer, intent(in)   :: npets, localpet
- 
- ! INTENT OUT 
+
+ ! INTENT OUT
  type(esmf_grid)                   :: gauss_grid
 
  type(esmf_polekind_flag)          :: polekindflag(2)
@@ -567,7 +567,7 @@
  call lonlat_read_into_fields(localpet, i_dim, j_dim,  &
                          trim(grid_setup%fname_coord), trim(grid_setup%dir_coord), &
                          grid_setup, gauss_grid, lon_fields, lat_fields)
- 
+
  staggerloc = (/ ESMF_STAGGERLOC_CENTER, ESMF_STAGGERLOC_CORNER /)
  do v = 1,2
      ! add coordinates to the grid
@@ -594,13 +594,13 @@
                         rc=ierr)
      if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
             call error_handler("IN FieldGet longitude", ierr)
-     
-     ! set coord pointe to field pointer 
+
+     ! set coord pointe to field pointer
      lon_ptr_coord = lon_ptr_field
 
      nullify(lat_ptr_coord)
      nullify(lat_ptr_field)
-     
+
      ! get pointer to lat coord. Need bounds?
      call ESMF_GridGetCoord(gauss_grid, &
                             staggerLoc=staggerloc(v), &
@@ -609,14 +609,14 @@
      if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
         call error_handler("IN GridGetCoord latitude", ierr)
 
-     ! fetch lat from field into pointer 
+     ! fetch lat from field into pointer
      call ESMF_FieldGet(lat_fields(v), &
                         farrayPtr=lat_ptr_field, &
                         rc=ierr)
      if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
             call error_handler("IN FieldGet latitude", ierr)
 
-     ! set lat coord to field values 
+     ! set lat coord to field values
      lat_ptr_coord =  lat_ptr_field
  enddo
 
@@ -629,7 +629,7 @@
      if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
         call error_handler("DESTROYING FIELD", ierr)
  enddo
-  
+
  end subroutine create_grid_gauss
 
 end  module grids_IO

--- a/src/regridStates/regridStates.F90
+++ b/src/regridStates/regridStates.F90
@@ -23,6 +23,7 @@
  
  ! namelist inputs
  character(len=15)              :: variable_list(max_vars)
+ character(len=2)               :: time_list(9)
  integer                        :: n_vars, n_tims
  real(esmf_kind_r8)             :: missing_value ! value given to unmapped cells in the output grid
 
@@ -30,6 +31,8 @@
 
  integer                        :: ierr, localpet, npets
  integer                        :: v, t, SRCTERM
+  
+ character(100)                 :: fname_time
  
  type(esmf_vm)                  :: vm
  type(esmf_grid)                :: grid_in, grid_out
@@ -43,7 +46,7 @@
  real :: t1, t2, t3, t4
 
  ! see README for details of namelist variables.
- namelist /config/ n_vars, n_tims,variable_list, missing_value
+ namelist /config/ n_vars, n_tims, time_list, variable_list, missing_value
 
 ! INITIALIZE
 !-------------------------------------------------------------------------
@@ -154,10 +157,16 @@
 !------------------------
 ! read data into input fields
 
-! CSD. 2 readin different times
  do t = 1, n_tims
+
+        if (n_tims>1) then
+                fname_time = trim(grid_setup_in%fname)//"."//time_list(t)
+        else
+                fname_time = trim(grid_setup_in%fname)
+        endif
+        write(6,*) 'reading into ', trim(fname_time)
         call read_into_fields(localpet, grid_setup_in%ires, grid_setup_in%jres, &
-                                 trim(grid_setup_in%fname), trim(grid_setup_in%dir), &
+                                 trim(fname_time), trim(grid_setup_in%dir), &
                                  grid_setup_in, n_vars, variable_list(1:n_vars), fields_in(t,:)) 
  enddo
 
@@ -210,7 +219,7 @@
 
  if (localpet==0) print*,'** Writing out regridded fields'
 
- call write_from_fields(localpet, grid_setup_out%ires, grid_setup_out%jres, n_tims, &
+ call write_from_fields(localpet, grid_setup_out%ires, grid_setup_out%jres,     &
                           trim(grid_setup_out%fname), trim(grid_setup_out%dir), &
                           n_vars, n_tims, variable_list(1:n_vars), fields_out)
 

--- a/src/regridStates/regridStates.F90
+++ b/src/regridStates/regridStates.F90
@@ -2,7 +2,7 @@
 ! Program to re-grid a list of FV3 variables.
 ! Intended for use in DA applications (regridding of restarts for recentering, regridding increments).
 !
-! Clara Draper, and George Gayno  Aug, 2024. 
+! Clara Draper, and George Gayno  Aug, 2024.
 
 ! TO DO - add option to pre-compute, and read in regridding route.
 
@@ -20,7 +20,7 @@
  implicit none
 
  integer, parameter             :: max_vars = 10  ! increase if wish to specify more variables
- 
+
  ! namelist inputs
  character(len=15)              :: variable_list(max_vars)
  character(len=2)               :: time_list(9)
@@ -31,16 +31,16 @@
 
  integer                        :: ierr, localpet, npets
  integer                        :: v, t, SRCTERM
-  
+
  character(100)                 :: fname_time
- 
+
  type(esmf_vm)                  :: vm
  type(esmf_grid)                :: grid_in, grid_out
- type(esmf_field), allocatable  :: fields_in(:,:) 
- type(esmf_field), allocatable  :: fields_out(:,:) 
+ type(esmf_field), allocatable  :: fields_in(:,:)
+ type(esmf_field), allocatable  :: fields_out(:,:)
  type(esmf_routehandle)         :: regrid_route
  real(esmf_kind_r8), pointer    :: ptr_out(:,:)
- 
+
  integer :: ut
 
  real :: t1, t2, t3, t4
@@ -73,7 +73,7 @@
 
  print*,'** pets: local, total: ',localpet, npets
 
- ! checks 
+ ! checks
 
  if (mod(npets,n_tiles) /= 0) then
    call error_handler("must run with a task count that is a multiple of 6", 1)
@@ -83,9 +83,9 @@
 ! read in namelist
 
  ! defaults
- missing_value=-999. 
+ missing_value=-999.
  extrap_levs=2
- n_tims=1 
+ n_tims=1
 
  open(newunit=ut, file='regrid.nml', iostat=ierr)
  if (ierr /= 0) call error_handler("OPENING regrid NAMELIST.", ierr)
@@ -94,7 +94,7 @@
  call readin_setup(ut,"input",grid_setup_in)
  call readin_setup(ut,"output",grid_setup_out)
  close (ut)
-  
+
 
 !------------------------
 ! Create esmf grid objects for input and output grids, and add land masks
@@ -103,7 +103,7 @@
 
  if (localpet==0) print*,'** Setting up grids'
  call setup_grid(localpet, npets, grid_setup_in, grid_in )
- 
+
  call setup_grid(localpet, npets, grid_setup_out, grid_out )
 
 !------------------------
@@ -112,47 +112,47 @@
  if (localpet==0) print*,'** Creating/Reading fields'
 
 ! input
- allocate(fields_in(n_tims,n_vars)) 
+ allocate(fields_in(n_tims,n_vars))
 
  do t = 1, n_tims
- do v = 1, n_vars
+     do v = 1, n_vars
 
-    fields_in(t,v)  = ESMF_FieldCreate(grid_in, &
-                        typekind=ESMF_TYPEKIND_R8, &
-                        staggerloc=ESMF_STAGGERLOC_CENTER, &
-                        name="input for regridding", &
-                        rc=ierr)
+        fields_in(t,v)  = ESMF_FieldCreate(grid_in, &
+                            typekind=ESMF_TYPEKIND_R8, &
+                            staggerloc=ESMF_STAGGERLOC_CENTER, &
+                            name="input for regridding", &
+                            rc=ierr)
 
-    if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
-       call error_handler("in FieldCreate "//trim(variable_list(v)), ierr)
- end do
+        if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
+           call error_handler("in FieldCreate "//trim(variable_list(v)), ierr)
+     end do
  end do
 
 ! output
- allocate(fields_out(n_tims,n_vars)) 
+ allocate(fields_out(n_tims,n_vars))
 
  do t = 1, n_tims
- do v = 1, n_vars
+     do v = 1, n_vars
 
-     fields_out(t,v)  = ESMF_FieldCreate(grid_out, &
-                                       typekind=ESMF_TYPEKIND_R8, &
-                                       staggerloc=ESMF_STAGGERLOC_CENTER, &
-                                       name="output of regridding", &
-                                       rc=ierr)
-     if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
-     call error_handler("in FieldCreate, field_out", ierr)
+         fields_out(t,v)  = ESMF_FieldCreate(grid_out, &
+                                           typekind=ESMF_TYPEKIND_R8, &
+                                           staggerloc=ESMF_STAGGERLOC_CENTER, &
+                                           name="output of regridding", &
+                                           rc=ierr)
+         if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
+         call error_handler("in FieldCreate, field_out", ierr)
 
 
-     ! set the default output value (for non-mapped cells) 
-     call ESMF_FieldGet(fields_out(t,v), &
-                        farrayPtr=ptr_out, &
-                        rc=ierr)
-     if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
-     call error_handler("IN FieldGet", ierr)
+         ! set the default output value (for non-mapped cells)
+         call ESMF_FieldGet(fields_out(t,v), &
+                            farrayPtr=ptr_out, &
+                            rc=ierr)
+         if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
+         call error_handler("IN FieldGet", ierr)
 
-     ptr_out=missing_value
+         ptr_out=missing_value
 
- enddo
+     enddo
  enddo
 
 !------------------------
@@ -168,7 +168,7 @@
         write(6,*) 'reading into ', trim(fname_time)
         call read_into_fields(localpet, grid_setup_in%ires, grid_setup_in%jres, &
                                  trim(fname_time), trim(grid_setup_in%dir), &
-                                 grid_setup_in, n_vars, variable_list(1:n_vars), fields_in(t,:)) 
+                                 grid_setup_in, n_vars, variable_list(1:n_vars), fields_in(t,:))
  enddo
 
  call cpu_time(t2)
@@ -186,12 +186,12 @@
                             unmappedaction=ESMF_UNMAPPEDACTION_IGNORE, &
                             polemethod=ESMF_POLEMETHOD_ALLAVG, &
                             ! fill un-mapped grid cells with a neighbour
-                            extrapMethod=ESMF_EXTRAPMETHOD_CREEP, & 
+                            extrapMethod=ESMF_EXTRAPMETHOD_CREEP, &
                             ! number of "levels" of neighbours to search for a value
                             extrapNumLevels=extrap_levs, &
                             ! needed for reproducibility
                             ! (combined with ESMF_TERMORDER_SRCSEQ below)
-                            srctermprocessing=SRCTERM, & 
+                            srctermprocessing=SRCTERM, &
                             routehandle=regrid_route, &
                             ! use bilinear interp (slightly better results than PATCH)
                             regridmethod=ESMF_REGRIDMETHOD_BILINEAR, rc=ierr)
@@ -203,15 +203,15 @@
  call cpu_time(t3)
 
  do t=1, n_tims
- do v=1, n_vars
-     call ESMF_FieldRegrid(fields_in(t,v), &
-                           fields_out(t,v), &
-                           routehandle=regrid_route, &
-                           zeroregion=ESMF_REGION_SELECT, & ! initialize output with missing_value
-                           termorderflag=ESMF_TERMORDER_SRCSEQ, rc=ierr)
-     if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
-      call error_handler("IN FieldRegrid", ierr)
- enddo
+     do v=1, n_vars
+         call ESMF_FieldRegrid(fields_in(t,v), &
+                               fields_out(t,v), &
+                               routehandle=regrid_route, &
+                               zeroregion=ESMF_REGION_SELECT, & ! initialize output with missing_value
+                               termorderflag=ESMF_TERMORDER_SRCSEQ, rc=ierr)
+         if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
+          call error_handler("IN FieldRegrid", ierr)
+     enddo
  enddo
 
 ! TO-DO: terrain-correct temperatures (all layers?)
@@ -225,22 +225,22 @@
                           n_vars, n_tims, variable_list(1:n_vars), fields_out)
 
 
-! clean up 
+! clean up
 
  call ESMF_FieldRegridRelease(routehandle=regrid_route, rc=ierr)
  if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
     call error_handler("IN FieldRegridRelease", ierr)
- 
- do t = 1, n_tims
- do v = 1, n_vars
-     call ESMF_FieldDestroy(fields_in(t,v),rc=ierr)
-     if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
-            call error_handler("DESTROYING FIELD", ierr)
 
-     call ESMF_FieldDestroy(fields_out(t,v),rc=ierr)
-     if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
-        call error_handler("DESTROYING FIELD", ierr)
- enddo
+ do t = 1, n_tims
+     do v = 1, n_vars
+         call ESMF_FieldDestroy(fields_in(t,v),rc=ierr)
+         if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
+                call error_handler("DESTROYING FIELD", ierr)
+
+         call ESMF_FieldDestroy(fields_out(t,v),rc=ierr)
+         if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
+            call error_handler("DESTROYING FIELD", ierr)
+     enddo
  enddo
 
  call ESMF_GridDestroy(grid_in,rc=ierr)
@@ -250,7 +250,7 @@
  call ESMF_GridDestroy(grid_out,rc=ierr)
  if(ESMF_logFoundError(rcToCheck=ierr,msg=ESMF_LOGERR_PASSTHRU,line=__LINE__,file=__FILE__)) &
     call error_handler("DESTROYING GRID", ierr)
- 
+
 !-------------------------------------------------------------------------
 ! FINALIZE
 !-------------------------------------------------------------------------
@@ -267,9 +267,9 @@
  end program regridStates
 
  subroutine readin_setup(unt,namel,grid_setup)
-! subroutine to read in namelists, and convert 
-! values into setupgrid. 
-! Also fills in some values, and tests have all 
+! subroutine to read in namelists, and convert
+! values into setupgrid.
+! Also fills in some values, and tests have all
 ! needed vals, according to the selected grid type.
 
  use grids_IO, only     : grid_setup_type
@@ -302,48 +302,48 @@
                     fname_coord, dir_coord,&
                     ires, jres
 
- ! set defaults 
+ ! set defaults
  fname = default_str
  dir = default_str
  fname_mask = default_str
  dir_mask = default_str
  fname_coord = default_str
  dir_coord = default_str
- ires = 0 
+ ires = 0
  jres = 0
 
  select case (namel)
- case ("input") 
+ case ("input")
      read(unt, nml=input, iostat=ierr)
      if (ierr /= 0) call error_handler("READING input NAMELIST.", ierr)
  case ("output")
      read(unt, nml=output, iostat=ierr)
      if (ierr /= 0) call error_handler("READING output NAMELIST.", ierr)
- case default 
+ case default
      call error_handler("unknown namel in readin_setup", 1)
- end select  
+ end select
 
  grid_setup%descriptor = gridtype
 
  grid_setup%dir = dir
- grid_setup%fname = fname 
+ grid_setup%fname = fname
 
  ! set-up mask details, based on file type
- select case (gridtype) 
- case ("fv3_rst") ! for history file and restarts, use veg type 
+ select case (gridtype)
+ case ("fv3_rst") ! for history file and restarts, use veg type
      grid_setup%dir_mask = dir_mask ! get from a fix file
      grid_setup%fname_mask = fname_mask
      grid_setup%mask_variable(1) =  "vegetation_type" ! if getting from fix file
  case ("gau_inc") ! gsi-output incr files only, use calculated mask
      if (trim(fname_mask) == default_str) then ! if not specified, use input file
-         grid_setup%dir_mask = dir 
-         grid_setup%fname_mask = fname 
+         grid_setup%dir_mask = dir
+         grid_setup%fname_mask = fname
      else
          grid_setup%dir_mask = dir_mask
          grid_setup%fname_mask = fname_mask
      endif
-     grid_setup%mask_variable(1) =  "soilsnow_mask  "  
- case default 
+     grid_setup%mask_variable(1) =  "soilsnow_mask  "
+ case default
      call error_handler("unknown gridtype in readin_setup", 1)
  end select
 


### PR DESCRIPTION
This PR expands the regriding code to read in multiple increments and regrid them into the same output file. 

Resolves issue [8](https://github.com/NOAA-EMC/DA-utils/issues/8)
Tests completed:
Using a single input file, the output file is unchanged. 
Using multiple input files, the output file can be read in by the GFS and applied as IAU. 