### PR TITLE
Fixed bug in character length for resolutions above 999.

### DIFF
--- a/src/regridStates/grids_IO.F90
+++ b/src/regridStates/grids_IO.F90
@@ -509,7 +509,7 @@
  enddo
 
  ! mosaic file
- write(rchar,'(i3)') res_atm
+ write(rchar,'(i5)') res_atm
  dir_fix_res = dir_fix//"/C"//trim(adjustl(rchar))//"/"
  fname = trim(dir_fix_res)//"/C"//trim(adjustl(rchar))// "_mosaic.nc"
 


### PR DESCRIPTION
Changed rchar from 3 to 5 to accommodate resolutions with more than 3 characters

resolves issue [14](https://github.com/NOAA-EMC/DA-utils/issues/14)