### PR TITLE
Make ioda-stats executable parallel with MPI

### DIFF
--- a/src/ioda-stats/iodastats.h
+++ b/src/ioda-stats/iodastats.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "eckit/config/LocalConfiguration.h"
+#include "eckit/mpi/Comm.h"
 
 #include "ioda/Engines/EngineUtils.h"
 #include "ioda/Group.h"
@@ -55,6 +56,9 @@ namespace dautils {
         std::vector<eckit::LocalConfiguration> obsSpaces;
         fullConfig.get("obs spaces", obsSpaces);
 
+        // get the communicator for just me
+        const eckit::mpi::Comm & mycomm = oops::mpi::myself();
+
         // get MPI comm size
         int nprocs = getComm().size();
         for (int i = getComm().rank(); i < obsSpaces.size(); i+= nprocs) {
@@ -66,7 +70,7 @@ namespace dautils {
           std::string obsFile;
           obsConfig.get("obsdatain.engine.obsfile", obsFile);
           oops::Log::info() << "IODA-Stats: Processing " << obsFile << std::endl;
-          ioda::ObsSpace ospace(obsConfig, getComm(), timeWindow, getComm());
+          ioda::ObsSpace ospace(obsConfig, mycomm, timeWindow, mycomm);
           const size_t nlocs = ospace.nlocs();
           oops::Log::info() << obsFile << ": nlocs =" << nlocs << std::endl;
 

--- a/src/ioda-stats/iodastats.h
+++ b/src/ioda-stats/iodastats.h
@@ -55,8 +55,9 @@ namespace dautils {
         std::vector<eckit::LocalConfiguration> obsSpaces;
         fullConfig.get("obs spaces", obsSpaces);
 
-        // for now, just do this serially, eventually, make it parallelized
-        for (int i = 0; i < obsSpaces.size(); i++) {
+        // get MPI comm size
+        int nprocs = getComm().size();
+        for (int i = getComm().rank(); i < obsSpaces.size(); i+= nprocs) {
           // get the configuration for this obs space
           auto obsSpace = obsSpaces[i];
           eckit::LocalConfiguration obsConfig(obsSpace, "obs space");


### PR DESCRIPTION
This now allows for obs spaces to be processed in parallel to save compute time