### PR TITLE
Add support for radiances/channels in ioda-stats

### DIFF
--- a/src/ioda-stats/calcstats.h
+++ b/src/ioda-stats/calcstats.h
@@ -22,12 +22,11 @@ namespace dautils {
         counts.push_back(count);
       } else {
         int _nlocs = data.size() / channels.size();
-        int count(0);
         for (int ch = 0; ch < channels.size(); ch++) {
-          int _start = ch * _nlocs;
-          int _end = _start + _nlocs;
-          for (size_t i = _start; i < _end; ++i) {
-            if (data[i] != fillVal_ && qcvals[i] == 0 && mask[i-_start] == 0) {
+          int count(0);
+          for (size_t i = 0; i < _nlocs; ++i) {
+            int ii = ch + (i * channels.size());
+            if (data[ii] != fillVal_ && qcvals[ii] == 0 && mask[i] == 0) {
               count += 1;
             }
           }
@@ -45,7 +44,7 @@ namespace dautils {
       if (channels.empty()) {
         int count(0);
         float mean(0.0);
-        float sum(0.0);
+        double sum(0.0);
         for (size_t i = 0; i < data.size(); ++i) {
           if (data[i] != fillVal_ && qcvals[i] == 0 && mask[i] == 0) {
             count += 1;
@@ -63,13 +62,12 @@ namespace dautils {
         for (int ch = 0; ch < channels.size(); ch++) {
           int count(0);
           float mean(0.0);
-          float sum(0.0);
-          int _start = ch * _nlocs;
-          int _end = _start + _nlocs;
-          for (size_t i = _start; i < _end; ++i) {
-            if (data[i] != fillVal_ && qcvals[i] == 0 && mask[i-_start] == 0) {
+          double sum(0.0);
+          for (size_t i = 0; i < _nlocs; ++i) {
+            int ii = ch + (i * channels.size());
+            if (data[ii] != fillVal_ && qcvals[ii] == 0 && mask[i] == 0) {
               count += 1;
-              sum += data[i];
+              sum += data[ii];
             }
           }
           if (count > 0) {
@@ -91,7 +89,7 @@ namespace dautils {
       if (channels.empty()) {
         int count(0);
         float rms(0.0);
-        float sum(0.0);
+        double sum(0.0);
         for (size_t i = 0; i < data.size(); ++i) {
           if (data[i] != fillVal_ && qcvals[i] == 0 && mask[i] == 0) {
             count += 1;
@@ -109,13 +107,14 @@ namespace dautils {
         for (int ch = 0; ch < channels.size(); ch++) {
           int count(0);
           float rms(0.0);
-          float sum(0.0);
+          double sum(0.0);
           int _start = ch * _nlocs;
           int _end = _start + _nlocs;
-          for (size_t i = _start; i < _end; ++i) {
-            if (data[i] != fillVal_ && qcvals[i] == 0 && mask[i-_start] == 0) {
+          for (size_t i = 0; i < _nlocs; ++i) {
+            int ii = ch + (i * channels.size());
+            if (data[ii] != fillVal_ && qcvals[ii] == 0 && mask[i] == 0) {
               count += 1;
-              sum += pow(data[i], 2);
+              sum += pow(data[ii], 2);
             }
           }
           if (count > 0) {

--- a/src/ioda-stats/calcstats.h
+++ b/src/ioda-stats/calcstats.h
@@ -21,8 +21,17 @@ namespace dautils {
         }
         counts.push_back(count);
       } else {
+        int _nlocs = data.size() / channels.size();
+        int count(0);
         for (int ch = 0; ch < channels.size(); ch++) {
-          oops::Log::info() << ch << std::endl;
+          int _start = ch * _nlocs;
+          int _end = _start + _nlocs;
+          for (size_t i = _start; i < _end; ++i) {
+            if (data[i] != fillVal_ && qcvals[i] == 0 && mask[i-_start] == 0) {
+              count += 1;
+            }
+          }
+          counts.push_back(count);
         }
       }
       return counts;
@@ -50,23 +59,27 @@ namespace dautils {
         }
         means.push_back(mean);
       } else {
+        int _nlocs = data.size() / channels.size();
         for (int ch = 0; ch < channels.size(); ch++) {
-          oops::Log::info() << ch << std::endl;
+          int count(0);
+          float mean(0.0);
+          float sum(0.0);
+          int _start = ch * _nlocs;
+          int _end = _start + _nlocs;
+          for (size_t i = _start; i < _end; ++i) {
+            if (data[i] != fillVal_ && qcvals[i] == 0 && mask[i-_start] == 0) {
+              count += 1;
+              sum += data[i];
+            }
+          }
+          if (count > 0) {
+            mean = sum / count;
+          } else {
+            mean = fillVal_;
+          }
+          means.push_back(mean);
         }
       }
-    //   if (channels.empty()) {
-    //     int count(0);
-    //     for (size_t i = 0; i < data.size(); ++i) {
-    //       if (data[i] != fillVal_ && qcvals[i] == 0) {
-    //         count += 1;
-    //       }
-    //     }
-    //     counts.push_back(count);
-    //   } else {
-    //     for (int ch = 0; ch < channels.size(); ch++) {
-    //       oops::Log::info() << ch << std::endl;
-    //     }
-    //   }
       return means;
     }
     // -----------------------------------------------------------------------------
@@ -92,23 +105,27 @@ namespace dautils {
         }
         rmsvals.push_back(rms);
       } else {
+        int _nlocs = data.size() / channels.size();
         for (int ch = 0; ch < channels.size(); ch++) {
-          oops::Log::info() << ch << std::endl;
+          int count(0);
+          float rms(0.0);
+          float sum(0.0);
+          int _start = ch * _nlocs;
+          int _end = _start + _nlocs;
+          for (size_t i = _start; i < _end; ++i) {
+            if (data[i] != fillVal_ && qcvals[i] == 0 && mask[i-_start] == 0) {
+              count += 1;
+              sum += pow(data[i], 2);
+            }
+          }
+          if (count > 0) {
+            rms = sqrt(sum / count);
+          } else {
+            rms = fillVal_;
+          }
+          rmsvals.push_back(rms);
         }
       }
-    //   if (channels.empty()) {
-    //     int count(0);
-    //     for (size_t i = 0; i < data.size(); ++i) {
-    //       if (data[i] != fillVal_ && qcvals[i] == 0) {
-    //         count += 1;
-    //       }
-    //     }
-    //     counts.push_back(count);
-    //   } else {
-    //     for (int ch = 0; ch < channels.size(); ch++) {
-    //       oops::Log::info() << ch << std::endl;
-    //     }
-    //   }
       return rmsvals;
     }
     // -----------------------------------------------------------------------------

--- a/src/ioda-stats/calcstats.h
+++ b/src/ioda-stats/calcstats.h
@@ -108,8 +108,6 @@ namespace dautils {
           int count(0);
           float rms(0.0);
           double sum(0.0);
-          int _start = ch * _nlocs;
-          int _end = _start + _nlocs;
           for (size_t i = 0; i < _nlocs; ++i) {
             int ii = ch + (i * channels.size());
             if (data[ii] != fillVal_ && qcvals[ii] == 0 && mask[i] == 0) {

--- a/src/ioda-stats/iodastats.h
+++ b/src/ioda-stats/iodastats.h
@@ -276,23 +276,46 @@ namespace dautils {
             }
             // loop over domains, compute the masks for each
             oops::Log::info() << "--------------------------------------------" << std::endl;
-            std::vector<std::vector<int>> binmask(zBinNames.size() * nbins_x * nbins_y, std::vector<int>(nlocs, 0));
-            int ibin = 0;
-            for (int idom = 0; idom < zBinNames.size(); idom++ ) {
-              oops::Log::info() << "Now processing binned data for vertical bin: " << zBinNames[idom] << std::endl;
+            int nzbins;
+            if (channels.empty()) {
+              nzbins = zBinNames.size();
+            } else {
+              nzbins = 1;
+            }
+            std::vector<std::vector<int>> binmask(nzbins * nbins_x * nbins_y, std::vector<int>(nlocs, 0));
+            if (channels.empty()) { // use vertical bins
+              int ibin = 0;
+              for (int idom = 0; idom < zBinNames.size(); idom++ ) {
+                oops::Log::info() << "Now processing binned data for vertical bin: " << zBinNames[idom] << std::endl;
+                oops::Log::info() << "nbins_x: " << nbins_x << " nbins_y: " << nbins_y << std::endl;
+                // compute masks for the bins
+                ObsStats obstatbinmask;
+                std::vector<float> xmaskvalues(nlocs), ymaskvalues(nlocs), zmaskvalues(nlocs);
+                if (!zBinMaskVar[idom].empty()) {
+                  ospace.get_db("MetaData", zBinMaskVar[idom], zmaskvalues);
+                }
+                ospace.get_db("MetaData", "latitude", ymaskvalues);
+                ospace.get_db("MetaData", "longitude", xmaskvalues);
+                for (int iy=0; iy < nbins_y; iy++) {
+                  for (int ix=0; ix < nbins_x; ix++) {
+                    ibin = ix + (iy * nbins_x) + (idom * nbins_x * nbins_y);
+                    binmask[ibin] = obstatbinmask.update_mask(zmaskvalues, zBinMaskVals[idom][0], zBinMaskVals[idom][1], binmask[ibin]);
+                    binmask[ibin] = obstatbinmask.update_mask(ymaskvalues, latitudes[iy], latitudes[iy+1], binmask[ibin]);
+                    binmask[ibin] = obstatbinmask.update_mask(xmaskvalues, longitudes[ix], longitudes[ix+1], binmask[ibin]);
+                  }
+                }
+              }
+            } else { // assumes channels
+              int ibin = 0;
               oops::Log::info() << "nbins_x: " << nbins_x << " nbins_y: " << nbins_y << std::endl;
               // compute masks for the bins
               ObsStats obstatbinmask;
-              std::vector<float> xmaskvalues(nlocs), ymaskvalues(nlocs), zmaskvalues(nlocs);
-              if (!zBinMaskVar[idom].empty()) {
-                ospace.get_db("MetaData", zBinMaskVar[idom], zmaskvalues);
-              }
+              std::vector<float> xmaskvalues(nlocs), ymaskvalues(nlocs);
               ospace.get_db("MetaData", "latitude", ymaskvalues);
               ospace.get_db("MetaData", "longitude", xmaskvalues);
               for (int iy=0; iy < nbins_y; iy++) {
                 for (int ix=0; ix < nbins_x; ix++) {
-                  ibin = ix + (iy * nbins_x) + (idom * nbins_x * nbins_y);
-                  binmask[ibin] = obstatbinmask.update_mask(zmaskvalues, zBinMaskVals[idom][0], zBinMaskVals[idom][1], binmask[ibin]);
+                  ibin = ix + (iy * nbins_x);
                   binmask[ibin] = obstatbinmask.update_mask(ymaskvalues, latitudes[iy], latitudes[iy+1], binmask[ibin]);
                   binmask[ibin] = obstatbinmask.update_mask(xmaskvalues, longitudes[ix], longitudes[ix+1], binmask[ibin]);
                 }
@@ -321,13 +344,50 @@ namespace dautils {
                 // loop over stats
                 ObsStats obstat;
                 for (int s = 0; s < stats.size(); s++) {
-                  // loop over bins
-                  for (int idom = 0; idom < zBinNames.size(); idom++ ) {
-                    std::vector<std::vector<float>> fullfloatstat(nbins_y, std::vector<float>(nbins_x,0.0));
-                    std::vector<std::vector<int>> fullintstat(nbins_y, std::vector<int>(nbins_x,0.0));
+                  if (channels.empty()) {
+                    // loop over bins
+                    int ibin = 0;
+                    for (int idom = 0; idom < zBinNames.size(); idom++ ) {
+                      std::vector<std::vector<float>> fullfloatstat(nbins_y, std::vector<float>(nbins_x,0.0));
+                      std::vector<std::vector<int>> fullintstat(nbins_y, std::vector<int>(nbins_x,0.0));
+                      for (int iy=0; iy < nbins_y; iy++) {
+                        for (int ix=0; ix < nbins_x; ix++) {
+                          ibin = ix + (iy * nbins_x) + (idom * nbins_x * nbins_y);
+                          // Maybe eventually set this up as a factory but for now just do it
+                          // with this old school if/else if way
+                          std::vector<int> intstat;
+                          std::vector<float> floatstat;
+                          if (stats[s] == "count") {
+                            intstat = obstat.getObsCount(buffer, qcflag, channels, binmask[ibin]);
+                          } else if (stats[s] == "mean") {
+                            floatstat = obstat.getMean(buffer, qcflag, channels, binmask[ibin]);
+                          } else if (stats[s] == "RMS") {
+                            floatstat = obstat.getRMS(buffer, qcflag, channels, binmask[ibin]);
+                          }
+                          if (stats[s] == "count") {
+                            fullintstat[iy][ix] = intstat[0];
+                          } else {
+                            fullfloatstat[iy][ix] = floatstat[0];  
+                          }
+                        }
+                      }
+                      if (stats[s] == "count") {
+                        statfile.writeByBins(outfile, groups[g], variables[var],
+                                            stats[s], idom, nbins_y, nbins_x, fullintstat);                  
+                      } else {
+                        statfile.writeByBins(outfile, groups[g], variables[var],
+                                            stats[s], idom, nbins_y, nbins_x, fullfloatstat);
+                      }
+                    }
+                  } else { // variable has channels not vertical bins
+                    std::vector<std::vector<std::vector<float>>> fullfloatstat(channels.size(),
+                      std::vector<std::vector<float>>(nbins_y,std::vector<float>(nbins_x, 0.0)));
+                    std::vector<std::vector<std::vector<int>>> fullintstat(channels.size(),
+                      std::vector<std::vector<int>>(nbins_y,std::vector<int>(nbins_x, 0.0)));
+                    int ibin = 0;
                     for (int iy=0; iy < nbins_y; iy++) {
                       for (int ix=0; ix < nbins_x; ix++) {
-                        ibin = ix + (iy * nbins_x) + (idom * nbins_x * nbins_y);
+                        ibin = ix + (iy * nbins_x);
                         // Maybe eventually set this up as a factory but for now just do it
                         // with this old school if/else if way
                         std::vector<int> intstat;
@@ -339,26 +399,32 @@ namespace dautils {
                         } else if (stats[s] == "RMS") {
                           floatstat = obstat.getRMS(buffer, qcflag, channels, binmask[ibin]);
                         }
-                        if (stats[s] == "count") {
-                          fullintstat[iy][ix] = intstat[0];
-                        } else {
-                          fullfloatstat[iy][ix] = floatstat[0];  
+                        // loop over channels
+                        for (int ich = 0; ich < channels.size(); ich++ ) {
+                          if (stats[s] == "count") {
+                            fullintstat[ich][iy][ix] = intstat[ich];
+                          } else {
+                            fullfloatstat[ich][iy][ix] = floatstat[ich];  
+                          }
                         }
                       }
                     }
-                    if (stats[s] == "count") {
-                      statfile.writeByBins(outfile, groups[g], variables[var],
-                                           stats[s], idom, nbins_y, nbins_x, fullintstat);                  
-                    } else {
-                      statfile.writeByBins(outfile, groups[g], variables[var],
-                                           stats[s], idom, nbins_y, nbins_x, fullfloatstat);
+                    // loop over channels
+                    for (int ich = 0; ich < channels.size(); ich++ ) {
+                      if (stats[s] == "count") {
+                        statfile.writeByBins(outfile, groups[g], variables[var],
+                                            stats[s], ich, nbins_y, nbins_x, fullintstat[ich]);                  
+                      } else {
+                        statfile.writeByBins(outfile, groups[g], variables[var],
+                                            stats[s], ich, nbins_y, nbins_x, fullfloatstat[ich]);
+                      }
                     }
-                  }
-                }
-              }
-            }
-          }
-        }
+                  } // channels vs bins
+                } // loop over stats
+              } // groups
+            } // variables 
+          } // if binning
+        } // communicator / obs space loop
         return 0;
       }
 

--- a/src/ioda-stats/statfile.h
+++ b/src/ioda-stats/statfile.h
@@ -39,7 +39,6 @@ namespace dautils {
       if (nbins_x > 0 || nbins_y > 0) {
         binningDimVector.push_back(tDim);
         if (!channels.empty()) {
-          cDim = ncFile.addDim("Channel", channels.size());
           binningDimVector.push_back(cDim);
         } else {
           zDim = ncFile.addDim("binsZDim", bins_z.size());
@@ -74,11 +73,13 @@ namespace dautils {
       }
 
       // create vertical bin variable
-      netCDF::NcVar zbins = ncFile.addVar("verticalBin", netCDF::ncString, zDim);
-      for (int ibin = 0; ibin < bins_z.size(); ibin++) {
-        std::vector<size_t> idxbin;
-        idxbin.push_back(ibin);
-        zbins.putVar(idxbin, bins_z[ibin]);
+      if (channels.empty()) {
+        netCDF::NcVar zbins = ncFile.addVar("verticalBin", netCDF::ncString, zDim);
+        for (int ibin = 0; ibin < bins_z.size(); ibin++) {
+          std::vector<size_t> idxbin;
+          idxbin.push_back(ibin);
+          zbins.putVar(idxbin, bins_z[ibin]);
+        }
       }
 
       // loop over group, then variables, then stats to create byDomains/group/var/stat in file
@@ -142,7 +143,16 @@ namespace dautils {
       std::vector<size_t> idxout;
       idxout.push_back(0);
       idxout.push_back(idom);
-      outvar.putVar(idxout, intvals[0]);
+      if (intvals.size() > 1) {
+        idxout.push_back(0);
+        std::vector<size_t> countout;
+        countout.push_back(1);
+        countout.push_back(1);
+        countout.push_back(intvals.size());
+        outvar.putVar(idxout, countout, intvals.data());
+      } else {
+        outvar.putVar(idxout, intvals[0]);
+      }
       return 0;
     };
 
@@ -156,7 +166,16 @@ namespace dautils {
       std::vector<size_t> idxout;
       idxout.push_back(0);
       idxout.push_back(idom);
-      outvar.putVar(idxout, floatvals[0]);
+      if (floatvals.size() > 1) {
+        idxout.push_back(0);
+        std::vector<size_t> countout;
+        countout.push_back(1);
+        countout.push_back(1);
+        countout.push_back(floatvals.size());
+        outvar.putVar(idxout, countout, floatvals.data());
+      } else {
+        outvar.putVar(idxout, floatvals[0]);
+      }
       return 0;
     };
 


### PR DESCRIPTION
Closes #21 

This PR adds in support for calculating stats for radiances by specified channel(s).

Example YAML:
```
time window:
  begin: 2021-07-31T21:00:00Z
  length: PT6H
  bound to include: begin
obs spaces:
- obs space:
    name: amsua_n19
    obsdatain:
      engine:
        type: H5File
        obsfile: ./diag_amsua_n19_2021080100.nc
    simulated variables: ['brightnessTemperature']
    observed variables: ['brightnessTemperature']
  variables: ['brightnessTemperature']
  channels: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]
  groups to process: ['hofx', 'ObsValue']
  qc groups: ['EffectiveQC', 'PreQC']
  statistics to compute: ['mean', 'count', 'RMS']
  output file: output_amsua_n19.nc
  regular grid binning:
    bin size in degrees: 2.0
  domains to process:
  - domain:
      name: "NH"
      first mask variable: latitude
      first mask range: [0,90]
  - domain:
      name: "SH"
      first mask variable: latitude
      first mask range: [-90,0]
```

Produces variables such as this (2 channels of AMSUA_N19 ObsValue at 2x2 degree bins for a single analysis)
![Screenshot from 2025-02-26 21-11-49](https://github.com/user-attachments/assets/c6956e87-c9ce-4ef6-ae60-02dda81327f0)
![Screenshot from 2025-02-26 21-11-23](https://github.com/user-attachments/assets/831b1b96-ae18-45cd-a546-7f1f35633195)


Apologies for my poor C++ in this PR and throughout this repo :-)