### PR TITLE
Fix GSI ncdiag converter dimension issue

### DIFF
--- a/ush/gsincdiag_to_ioda/gsi_ncdiag.py
+++ b/ush/gsincdiag_to_ioda/gsi_ncdiag.py
@@ -779,13 +779,13 @@ class Conv(BaseGSI):
         for v in self.obsvars:
             for p in platforms:
                 outname = OutDir + '/' + p + '_' + v + '_geoval_' + \
-                    self.validtime.strftime("%Y%m%d%H") + '.nc4'
+                    self.validtime.strftime("%Y%m%d%H") + '.nc'
                 if (v == 'sst'):
                     outname = OutDir + '/' + v + '_geoval_' + \
-                        self.validtime.strftime("%Y%m%d%H") + '.nc4'
+                        self.validtime.strftime("%Y%m%d%H") + '.nc'
                 if (p == 'windprof' or p == 'satwind' or p == 'scatwind' or p == 'vadwind' or p == 'pibal'):
                     outname = OutDir + '/' + p + '_geoval_' + \
-                        self.validtime.strftime("%Y%m%d%H") + '.nc4'
+                        self.validtime.strftime("%Y%m%d%H") + '.nc'
                 if not clobber:
                     if (os.path.exists(outname)):
                         print("File exists. Skipping and not overwriting:%s" % outname)
@@ -1265,7 +1265,7 @@ class Radiances(BaseGSI):
         # ioda_conv_ncio or equivalent to handle the format
         # set up output file
         outname = OutDir + '/' + self.sensor + '_' + self.satellite + \
-            '_geoval_' + self.validtime.strftime("%Y%m%d%H") + '.nc4'
+            '_geoval_' + self.validtime.strftime("%Y%m%d%H") + '.nc'
         if not clobber:
             if (os.path.exists(outname)):
                 print("File exists. Skipping and not overwriting:")
@@ -1334,7 +1334,7 @@ class Radiances(BaseGSI):
 
         # set up output file
         outname = OutDir + '/' + self.sensor + '_' + self.satellite + \
-            '_obsdiag_' + self.validtime.strftime("%Y%m%d%H") + '.nc4'
+            '_obsdiag_' + self.validtime.strftime("%Y%m%d%H") + '.nc'
         if not clobber:
             if (os.path.exists(outname)):
                 print("File exists. Skipping and not overwriting: %s" % outname)
@@ -1823,7 +1823,7 @@ class Ozone(BaseGSI):
         # ioda_conv_ncio or equivalent to handle the format
 
         # set up output file
-        outname = OutDir+'/'+self.sensor+'_'+self.satellite+'_geoval_'+self.validtime.strftime("%Y%m%d%H")+'.nc4'
+        outname = OutDir+'/'+self.sensor+'_'+self.satellite+'_geoval_'+self.validtime.strftime("%Y%m%d%H")+'.nc'
         if not clobber:
             if (os.path.exists(outname)):
                 print("File exists. Skipping and not overwriting: %s" % outname)
@@ -2061,7 +2061,7 @@ class Radar(BaseGSI):
         # ioda_conv_ncio or equivalent to handle the format
 
         # set up output file
-        outname = OutDir+'/'+self.sensor+'_'+self.obstype+'_geoval_'+self.validtime.strftime("%Y%m%d%H")+'.nc4'
+        outname = OutDir+'/'+self.sensor+'_'+self.obstype+'_geoval_'+self.validtime.strftime("%Y%m%d%H")+'.nc'
         if not clobber:
             if (os.path.exists(outname)):
                 print("File exists. Skipping and not overwriting: %s" % outname)

--- a/ush/gsincdiag_to_ioda/gsi_ncdiag.py
+++ b/ush/gsincdiag_to_ioda/gsi_ncdiag.py
@@ -691,21 +691,14 @@ gmi_chan_dep_loc_vars = {
     'Scan_Angle',
 }
 
-DimDict = {
-}
-
-VarDims = {
-}
-
-globalAttrs = {
-    'converter': os.path.basename(__file__),
-}
-
 
 class BaseGSI:
     EPSILON = 9e-12
     FLOAT_FILL = nc.default_fillvals['f4']
     INT_FILL = nc.default_fillvals['i4']
+
+    # Note: DimDict, VarDims, and globalAttrs are initialized per-instance
+    # in __init__ to avoid sharing mutable state between instances
 
     @staticmethod
     def _as_array(netcdf_var):
@@ -733,6 +726,13 @@ class Conv(BaseGSI):
       nobs        - number of observations
     """
     def __init__(self, filename):
+        # Initialize instance-specific mutable attributes
+        self.DimDict = {}
+        self.VarDims = {}
+        self.globalAttrs = {
+            'converter': os.path.basename(__file__),
+        }
+        
         self.filename = filename
         splitfname = self.filename.split('/')[-1].split('_')
         if 'conv' in splitfname:
@@ -911,13 +911,13 @@ class Conv(BaseGSI):
             for p in platforms:
                 # set up a NcWriter class
                 outname = OutDir + '/' + p + '_' + v + diagtype + \
-                    self.validtime.strftime("%Y%m%d%H") + '.nc4'
+                    self.validtime.strftime("%Y%m%d%H") + '.nc'
                 if (v == 'sst'):
                     outname = OutDir + '/' + v + diagtype + \
-                        self.validtime.strftime("%Y%m%d%H") + '.nc4'
+                        self.validtime.strftime("%Y%m%d%H") + '.nc'
                 if (p == 'windprof' or p == 'satwind' or p == 'scatwind' or p == 'vadwind' or p == 'pibal'):
                     outname = OutDir + '/' + p + diagtype + \
-                        self.validtime.strftime("%Y%m%d%H") + '.nc4'
+                        self.validtime.strftime("%Y%m%d%H") + '.nc'
                 if not clobber:
                     if (os.path.exists(outname)):
                         print("File exists. Skipping and not overwriting: %s" % outname)
@@ -953,7 +953,7 @@ class Conv(BaseGSI):
                     varDict[value]['valKey'] = value, iconv.OvalName()
                     varDict[value]['errKey'] = value, iconv.OerrName()
                     varDict[value]['qcKey'] = value, iconv.OqcName()
-                    VarDims[value] = ['Location']
+                    self.VarDims[value] = ['Location']
                     varAttrs[varDict[value]['valKey']]['units'] = units_values[value]
                     varAttrs[varDict[value]['errKey']]['units'] = units_values[value]
                     varAttrs[varDict[value]['valKey']]['coordinates'] = 'longitude latitude'
@@ -1089,7 +1089,7 @@ class Conv(BaseGSI):
                             iodavar = 'GsiBc'
                             gvname = outvars[o], iodavar
                             outdata[gvname] = np.reshape(tmp, np.shape(self.df.variables['Observation']))
-                            VarDims[gvname] = ['Location']
+                            self.VarDims[gvname] = ['Location']
                         else:
                             print(f' ... can not add total bias missing {key1} or {key2} from input file')
 
@@ -1163,10 +1163,10 @@ class Conv(BaseGSI):
                         outdata[(test_mdata_name, 'TestReference')] = tmp
 
                 # writer metadata
-                DimDict['Location'] = len(StationIDs)
+                self.DimDict['Location'] = len(StationIDs)
 
-                writer = iconv.IodaWriter(outname, LocKeyList, DimDict)
-                writer.BuildIoda(outdata, VarDims, varAttrs, globalAttrs)
+                writer = iconv.IodaWriter(outname, LocKeyList, self.DimDict)
+                writer.BuildIoda(outdata, self.VarDims, varAttrs, self.globalAttrs)
 
                 print("Processed %d Conventional obs processed to: %s" % (len(obsdata), outname))
 
@@ -1223,6 +1223,13 @@ class Radiances(BaseGSI):
     """
 
     def __init__(self, filename):
+        # Initialize instance-specific mutable attributes
+        self.DimDict = {}
+        self.VarDims = {}
+        self.globalAttrs = {
+            'converter': os.path.basename(__file__),
+        }
+        
         self.filename = filename
         splitfname = self.filename.split('/')[-1].split('_')
         i = False
@@ -1422,7 +1429,7 @@ class Radiances(BaseGSI):
             diagtype = "_obs_"
             varsuffix = ""
         outname = OutDir + '/' + self.sensor + '_' + self.satellite + \
-            diagtype + self.validtime.strftime("%Y%m%d%H") + '.nc4'
+            diagtype + self.validtime.strftime("%Y%m%d%H") + '.nc'
         if not clobber:
             if (os.path.exists(outname)):
                 print("File exists. Skipping and not overwriting: %s" % outname)
@@ -1470,7 +1477,7 @@ class Radiances(BaseGSI):
         varDict[value]['valKey'] = value, iconv.OvalName()
         varDict[value]['errKey'] = value, iconv.OerrName()
         varDict[value]['qcKey'] = value, iconv.OqcName()
-        VarDims[value] = ['Location', 'Channel']
+        self.VarDims[value] = ['Location', 'Channel']
         varAttrs[varDict[value]['valKey']]['units'] = 'K'
         varAttrs[varDict[value]['errKey']]['units'] = 'K'
 #       varAttrs[varDict[value]['qcKey']]['units'] = 'unitless'
@@ -1500,7 +1507,7 @@ class Radiances(BaseGSI):
             for vbc in valuebc:
                 varDict[vbc]['bctKey'] = vbc, iconv.ObiastermName()
                 varDict[vbc]['bcpKey'] = vbc, iconv.ObiaspredName()
-                VarDims[(vbc, 'MetaData')] = ['Location']
+                self.VarDims[(vbc, 'MetaData')] = ['Location']
                 ibc += 1
         obsdata = self.var('Observation')
         try:
@@ -1598,7 +1605,7 @@ class Radiances(BaseGSI):
                 tmp = self.var(tvar)[:]
                 tmp[tmp > 4e8] = self.FLOAT_FILL
                 outdata[test_mdata_name] = np.reshape(tmp, (nlocs, nchans))
-                VarDims[test_mdata_name] = ['Location', 'Channel']
+                self.VarDims[test_mdata_name] = ['Location', 'Channel']
                 if test_fields_with_channels_[tvar][0] in units_values.keys():
                     varAttrs[test_mdata_name]['units'] = units_values[test_fields_with_channels_[tvar][0]]
 
@@ -1607,7 +1614,7 @@ class Radiances(BaseGSI):
                 tmp = self.var(tvar)[::nchans]
                 tmp[tmp > 4e8] = self.FLOAT_FILL
                 outdata[test_mdata_name] = tmp
-                VarDims[test_mdata_name] = ['Location']
+                self.VarDims[test_mdata_name] = ['Location']
                 if test_fields_[tvar][0] in units_values.keys():
                     if tvar != 'scat_amsua':
                         varAttrs[test_mdata_name]['units'] = units_values[test_fields_[tvar][0]]
@@ -1655,7 +1662,7 @@ class Radiances(BaseGSI):
                     tmp[tmp > 4e8] = self.FLOAT_FILL
                 gvname = "brightnessTemperature", iodavar + varsuffix
                 outdata[gvname] = np.reshape(tmp, (nlocs, nchans))
-                VarDims[gvname] = ['Location', 'Channel']
+                self.VarDims[gvname] = ['Location', 'Channel']
 
         if (TotalBias):
             # compute final bias correction
@@ -1666,7 +1673,7 @@ class Radiances(BaseGSI):
                 iodavar = 'GsiBc' + varsuffix
                 gvname = "brightnessTemperature", iodavar
                 outdata[gvname] = np.reshape(tmp, (nlocs, nchans))
-                VarDims[gvname] = ['Location', 'Channel']
+                self.VarDims[gvname] = ['Location', 'Channel']
             else:
                 print(f' ... can not add total bias missing {key1} or {key2} from input file')
 
@@ -1741,7 +1748,7 @@ class Radiances(BaseGSI):
                     # Wavenumber unit is cm-1 in CRTM/GSI
                     if value2 == 'sensorCentralWavenumber':
                         outdata[(value2, 'MetaData')] = outdata[(value2, 'MetaData')]*1.e2
-                VarDims[(value2, 'MetaData')] = ['Channel']
+                self.VarDims[(value2, 'MetaData')] = ['Channel']
                 if value2 in units_values.keys():
                     varAttrs[(value2, 'MetaData')]['units'] = units_values[value2]
             except IndexError:
@@ -1749,11 +1756,11 @@ class Radiances(BaseGSI):
 
         # set dimension lengths in the writer since we are bypassing
         # ExtractObsData
-        DimDict['Location'] = nlocs
-        DimDict['Channel'] = chanlist
+        self.DimDict['Location'] = nlocs
+        self.DimDict['Channel'] = chanlist
 
-        writer = iconv.IodaWriter(outname, LocKeyList, DimDict)
-        writer.BuildIoda(outdata, VarDims, varAttrs, globalAttrs)
+        writer = iconv.IodaWriter(outname, LocKeyList, self.DimDict)
+        writer.BuildIoda(outdata, self.VarDims, varAttrs, self.globalAttrs)
 
         print("Satellite radiance obs processed, wrote to: %s" % outname)
 
@@ -1774,6 +1781,13 @@ class Ozone(BaseGSI):
 
     """
     def __init__(self, filename):
+        # Initialize instance-specific mutable attributes
+        self.DimDict = {}
+        self.VarDims = {}
+        self.globalAttrs = {
+            'converter': os.path.basename(__file__),
+        }
+        
         self.filename = filename
         splitfname = self.filename.split('/')[-1].split('_')
         i = False
@@ -1796,6 +1810,9 @@ class Ozone(BaseGSI):
         # number of observations
         self.nobs = len(df.dimensions['nobs'])
         self.df = df
+
+    def close(self):
+        self.df.close()
 
     def toGeovals(self, OutDir, clobber=True):
         """ toGeovals(OutDir,clobber=True)
@@ -1874,14 +1891,14 @@ class Ozone(BaseGSI):
         else:
             diagtype = "_obs_"
             varsuffix = ""
-        outname = OutDir+'/'+self.sensor+'_'+self.satellite+diagtype+self.validtime.strftime("%Y%m%d%H")+'.nc4'
+        outname = OutDir+'/'+self.sensor+'_'+self.satellite+diagtype+self.validtime.strftime("%Y%m%d%H")+'.nc'
         if not clobber:
             if (os.path.exists(outname)):
                 print("File exists. Skipping and not overwriting: %s" % outname)
                 return
         LocKeyList = []
         LocVars = []
-        globalAttrs = {}
+        self.globalAttrs = {}
         varDict = defaultdict(lambda: defaultdict(dict))
         outdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
         varAttrs = DefaultOrderedDict(lambda: DefaultOrderedDict(dict))
@@ -1898,7 +1915,7 @@ class Ozone(BaseGSI):
         varDict[vname]['valKey'] = vname, iconv.OvalName()
         varDict[vname]['errKey'] = vname, iconv.OerrName()
         varDict[vname]['qcKey'] = vname, iconv.OqcName()
-        VarDims[vname] = ['Location']
+        self.VarDims[vname] = ['Location']
         varAttrs[varDict[vname]['valKey']]['units'] = units_values[vname]
         varAttrs[varDict[vname]['errKey']]['units'] = units_values[vname]
         # varAttrs[varDict[vname]['qcKey']]['units'] = 'unitless'
@@ -1931,7 +1948,7 @@ class Ozone(BaseGSI):
                 outdata[(loc_mdata_name, 'MetaData')] = tmp
                 if loc_mdata_name in units_values.keys():
                     varAttrs[(loc_mdata_name, 'MetaData')]['units'] = units_values[loc_mdata_name]
-            VarDims[(loc_mdata_name, 'MetaData')] = ['Location']
+            self.VarDims[(loc_mdata_name, 'MetaData')] = ['Location']
 
         for gsivar, iodavar in gsi_add_vars.items():
             # some special actions need to be taken depending on var name...
@@ -1966,7 +1983,7 @@ class Ozone(BaseGSI):
                     iodavar = 'GsiBc' + varsuffix
                     gvname = vname, iodavar
                     outdata[gvname] = np.reshape(tmp, (nlocs))
-                    VarDims[gvname] = ['Location']
+                    self.VarDims[gvname] = ['Location']
                 else:
                     print(f' ... can not add total bias missing {key1} or {key2} from input file')
 
@@ -1984,10 +2001,10 @@ class Ozone(BaseGSI):
 
         # set dimension lengths in the writer since we are bypassing
         # ExtractObsData
-        DimDict['Location'] = nlocs
+        self.DimDict['Location'] = nlocs
 
-        writer = iconv.IodaWriter(outname, LocKeyList, DimDict)
-        writer.BuildIoda(outdata, VarDims, varAttrs, globalAttrs)
+        writer = iconv.IodaWriter(outname, LocKeyList, self.DimDict)
+        writer.BuildIoda(outdata, self.VarDims, varAttrs, self.globalAttrs)
         print("Ozone obs processed, wrote to: %s" % outname)
 
 
@@ -2006,6 +2023,13 @@ class Radar(BaseGSI):
 
     """
     def __init__(self, filename):
+        # Initialize instance-specific mutable attributes
+        self.DimDict = {}
+        self.VarDims = {}
+        self.globalAttrs = {
+            'converter': os.path.basename(__file__),
+        }
+        
         self.filename = filename
         splitfname = self.filename.split('/')[-1].split('_')
         i = False
@@ -2085,14 +2109,14 @@ class Radar(BaseGSI):
         to the JEDI/IODA observation format
         """
         # set up a NcWriter class
-        outname = OutDir+'/'+self.sensor+'_'+self.obstype+'_obs_'+self.validtime.strftime("%Y%m%d%H")+'.nc4'
+        outname = OutDir+'/'+self.sensor+'_'+self.obstype+'_obs_'+self.validtime.strftime("%Y%m%d%H")+'.nc'
         if not clobber:
             if (os.path.exists(outname)):
                 print("File exists. Skipping and not overwriting:%s" % outname)
                 return
         LocKeyList = []
         LocVars = []
-        globalAttrs = {}
+        self.globalAttrs = {}
         varDict = defaultdict(lambda: defaultdict(dict))
         outdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
         varAttrs = DefaultOrderedDict(lambda: DefaultOrderedDict(dict))
@@ -2118,7 +2142,7 @@ class Radar(BaseGSI):
             varDict[value]['valKey'] = value, iconv.OvalName()
             varDict[value]['errKey'] = value, iconv.OerrName()
             varDict[value]['qcKey'] = value, iconv.OqcName()
-            VarDims[value] = ['Location']
+            self.VarDims[value] = ['Location']
             varAttrs[varDict[value]['valKey']]['units'] = myunits
             varAttrs[varDict[value]['errKey']]['units'] = myunits
             varAttrs[varDict[value]['qcKey']]['units'] = 'unitless'
@@ -2170,13 +2194,13 @@ class Radar(BaseGSI):
                 if loc_mdata_name in units_values.keys():
                     varAttrs[(loc_mdata_name, 'MetaData')]['units'] = units_values[loc_mdata_name]
 
-        globalAttrs["sensor"] = self.sensor
+        self.globalAttrs["sensor"] = self.sensor
 
         # set dimension lengths in the writer since we are bypassing
         # ExtractObsData
-        DimDict['Location'] = nlocs
+        self.DimDict['Location'] = nlocs
 
-        writer = iconv.IodaWriter(outname, LocKeyList, DimDict)
-        writer.BuildIoda(outdata, VarDims, varAttrs, globalAttrs)
+        writer = iconv.IodaWriter(outname, LocKeyList, self.DimDict)
+        writer.BuildIoda(outdata, self.VarDims, varAttrs, self.globalAttrs)
 
         print("Radar obs processed, wrote to: %s" % outname)


### PR DESCRIPTION
Fixes using a single dictionary that gets modified for all GSI ncdiags to a separate dictionary for each instance of the class. This solves the issue of Channel dimensions showing up for conventional data after radiance data has been processed in a loop.

Also changed `.nc4` to `.nc` to match other filename conventions in other components