### PR TITLE
Look for Inverse_Observation_Error if Input_Observation_Error is not available in ozone files

### DIFF
--- a/ush/gsincdiag_to_ioda/gsi_ncdiag.py
+++ b/ush/gsincdiag_to_ioda/gsi_ncdiag.py
@@ -1927,8 +1927,10 @@ class Ozone(BaseGSI):
         try:
             tmp = self.var('Input_Observation_Error')
         except IndexError:
-            # tmp = 1./self.var('Inverse_Observation_Error')
-            tmp = np.repeat(self.var('error_variance'), nlocs, axis=0)
+            try:
+                tmp = 1./self.var('Inverse_Observation_Error')
+            except IndexError:
+                tmp = np.repeat(self.var('error_variance'), nlocs, axis=0)
         tmp[tmp < self.EPSILON] = 0
         obserr = tmp
         obserr[np.isinf(obserr)] = self.FLOAT_FILL


### PR DESCRIPTION
This addresses #51.

`ush/gsincdiag_to_ioda/gsi_ncdiag.py` looks for `Input_Observation_Error` in ozone diag files, bit this is not available before August 2025.

This observation error should not be needed for UFO anyway.

