### PR TITLE
Update restriction filters for atmos

### DIFF
--- a/src/ioda-restrict/ioda_restriction_filter.py
+++ b/src/ioda-restrict/ioda_restriction_filter.py
@@ -46,16 +46,18 @@ def copy_group(in_group, out_group, mask):
     # Copy group-level attributes
     for attr in in_group.ncattrs():
         setattr(out_group, attr, getattr(in_group, attr))
-    
+
     for var_name, var_in in in_group.variables.items():
         fill_value = getattr(var_in, "_FillValue", None)
 
-        # Determine whether compression is allowed (numeric only)
+        # Determine whether compression is allowed:
+        # - numeric dtype
+        # - non-scalar (HDF5 cannot deflate 0-D variables)
         dtype = var_in.dtype
-        can_compress = (
-            np.issubdtype(dtype, np.integer) or
-            np.issubdtype(dtype, np.floating)
-        )
+        is_numeric = np.issubdtype(dtype, np.integer) or np.issubdtype(dtype, np.floating)
+        has_dims = len(var_in.dimensions) > 0
+
+        can_compress = is_numeric and has_dims
 
         create_kwargs = {}
         if can_compress:
@@ -102,7 +104,7 @@ def copy_group(in_group, out_group, mask):
         copy_group(grp_in, grp_out, mask)
 
 # ----------------------------------------------------------------------
-# link non-restricted files-create symlink
+# non-restricted files are linked by creating a symlink
 # ----------------------------------------------------------------------
 def copy_entire_file(infile, outfile):
     # Remove existing file or symlink if present
@@ -110,11 +112,13 @@ def copy_entire_file(infile, outfile):
         try:
             os.remove(outfile)
         except Exception as e:
-            print(f"  WARNING: Could not remove existing file {outfile}: {e}")
+            raise OSError(f"Could not remove existing file {outfile}") from e
 
-    # Create symlink
-    os.symlink(infile, outfile)
-    print(f"  Linked (unchanged): {outfile} → {infile}")
+    # Create symlink using an absolute target so relative input paths do not
+    # become broken when resolved from the output directory.
+    link_target = os.path.abspath(infile)
+    os.symlink(link_target, outfile)
+    print(f"  Linked (unchanged): {outfile} → {link_target}")
 
 # ----------------------------------------------------------------------
 # Extract date from path (exprsrd mode)

--- a/src/ioda-restrict/ioda_restriction_filter.py
+++ b/src/ioda-restrict/ioda_restriction_filter.py
@@ -46,19 +46,39 @@ def copy_group(in_group, out_group, mask):
     # Copy group-level attributes
     for attr in in_group.ncattrs():
         setattr(out_group, attr, getattr(in_group, attr))
-
+    
     for var_name, var_in in in_group.variables.items():
         fill_value = getattr(var_in, "_FillValue", None)
 
+        # Determine whether compression is allowed (numeric only)
+        dtype = var_in.dtype
+        can_compress = (
+            np.issubdtype(dtype, np.integer) or
+            np.issubdtype(dtype, np.floating)
+        )
+
+        create_kwargs = {}
+        if can_compress:
+            create_kwargs = dict(zlib=True, complevel=4, shuffle=True)
+
+        # Create output variable
         if fill_value is not None:
             var_out = out_group.createVariable(
-                var_name, var_in.dtype, var_in.dimensions, fill_value=fill_value
+                var_name,
+                dtype,
+                var_in.dimensions,
+                fill_value=fill_value,
+                **create_kwargs
             )
         else:
             var_out = out_group.createVariable(
-                var_name, var_in.dtype, var_in.dimensions
+                var_name,
+                dtype,
+                var_in.dimensions,
+                **create_kwargs
             )
 
+        # Copy data (masked or full)
         data = var_in[:]
 
         if mask is None:
@@ -71,20 +91,30 @@ def copy_group(in_group, out_group, mask):
         else:
             var_out[:] = data
 
+        # Copy attributes
         for attr in var_in.ncattrs():
             if attr != "_FillValue":
                 setattr(var_out, attr, getattr(var_in, attr))
 
+    # Recurse into subgroups
     for grp_name, grp_in in in_group.groups.items():
         grp_out = out_group.createGroup(grp_name)
         copy_group(grp_in, grp_out, mask)
 
 # ----------------------------------------------------------------------
-# Copy entire file unchanged
+# link non-restricted files-create symlink
 # ----------------------------------------------------------------------
 def copy_entire_file(infile, outfile):
-    shutil.copy(infile, outfile)
-    print(f"  Wrote (unchanged): {outfile}")
+    # Remove existing file or symlink if present
+    if os.path.exists(outfile) or os.path.islink(outfile):
+        try:
+            os.remove(outfile)
+        except Exception as e:
+            print(f"  WARNING: Could not remove existing file {outfile}: {e}")
+
+    # Create symlink
+    os.symlink(infile, outfile)
+    print(f"  Linked (unchanged): {outfile} → {infile}")
 
 # ----------------------------------------------------------------------
 # Extract date from path (exprsrd mode)
@@ -379,13 +409,18 @@ def run_rsrd_exprsrd(stats_yaml):
 
     print(f"\nCluster check: dev_m={dev_m}, this_m={this_m}, run_exprsrd={run_exprsrd}")
 
-
     # --- 2. EXPRSRD filter on previous 48h cycle ---
     if run_exprsrd:
         prev_dir = get_prev_48h_dir(input_dir)
-        output_us = os.path.join(os.path.dirname(prev_dir), "atmos.us")
-        print("\n=== Running EXPRSRD filter (atmos.us) ===")
-        process_exprsrd_directory(prev_dir, output_us)
+
+        # Skip if previous directory does not exist or contains no .nc files
+        nc_files = glob.glob(os.path.join(prev_dir, "*.nc"))
+        if (not os.path.isdir(prev_dir)) or (len(nc_files) == 0):
+            print(f"\n=== Skipping EXPRSRD filter (no previous 48h files): {prev_dir} ===")
+        else:
+            output_us = os.path.join(os.path.dirname(prev_dir), "atmos.us")
+            print("\n=== Running EXPRSRD filter (atmos.us) ===")
+            process_exprsrd_directory(prev_dir, output_us)
     else:
         print("\n=== Skipping EXPRSRD filter (cluster mismatch) ===")
 
@@ -409,5 +444,3 @@ def cli():
 # ----------------------------------------------------------------------
 if __name__ == "__main__":
     cli()
-
-


### PR DESCRIPTION
This PR includes 
1. Unrestricted NetCDF files are now symlinked into both atmos.nr and atmos.us directories instead of being duplicated.
2. Newly generated restricted NetCDF files are written using compression. 
3. Bypasses the 48‑hour restriction logic when the previous cycle contains no .nc files.