### PR TITLE
Change exception handling from ioda to eckit

### DIFF
--- a/src/ioda-dump/ioda-dump.h
+++ b/src/ioda-dump/ioda-dump.h
@@ -469,7 +469,7 @@ namespace dautils {
                 // 1D data (no channels)
                 // 2D data (with channels), get_db() will read all channels into the 1D vector
                 ospace.get_db(group, variable, obsData);
-            } catch (const eckit::Exception& e) {
+            } catch (const eckit::Exception&) {
               oops::Log::info() << "Skipping missing variable: " << group << "/" << variable << std::endl;
               continue; // Skip to the next variable
             }

--- a/src/ioda-dump/ioda-dump.h
+++ b/src/ioda-dump/ioda-dump.h
@@ -469,7 +469,7 @@ namespace dautils {
                 // 1D data (no channels)
                 // 2D data (with channels), get_db() will read all channels into the 1D vector
                 ospace.get_db(group, variable, obsData);
-            } catch (const ioda::Exception& e) {
+            } catch (const eckit::Exception& e) {
               oops::Log::info() << "Skipping missing variable: " << group << "/" << variable << std::endl;
               continue; // Skip to the next variable
             }


### PR DESCRIPTION
JCSDA ioda PR [#1796](https://github.com/JCSDA-internal/ioda/pull/1796) replaced `ioda::Exception` with `eckit::Exception`.

This PR replaces `ioda::Exception` in `src/ioda-dump/ioda-dump.h` with `eckit::Exception`

Resolves #78